### PR TITLE
feat(infra): configure EF Core SQL Server DbContext and DI wiring

### DIFF
--- a/backend/src/PersonalFinanceTracker.Api/Program.cs
+++ b/backend/src/PersonalFinanceTracker.Api/Program.cs
@@ -1,8 +1,11 @@
+using PersonalFinanceTracker.Infrastructure;
+
 var builder = WebApplication.CreateBuilder(args);
 
 // Add services to the container.
 
 builder.Services.AddControllers();
+builder.Services.AddInfrastructure(builder.Configuration);
 // Learn more about configuring OpenAPI at https://aka.ms/aspnet/openapi
 builder.Services.AddOpenApi();
 

--- a/backend/src/PersonalFinanceTracker.Api/appsettings.Development.json
+++ b/backend/src/PersonalFinanceTracker.Api/appsettings.Development.json
@@ -1,4 +1,7 @@
 {
+  "ConnectionStrings": {
+    "DefaultConnection": "Server=localhost;Database=PersonalFinanceTrackerDb;Trusted_Connection=True;TrustServerCertificate=True;MultipleActiveResultSets=true"
+  },
   "Logging": {
     "LogLevel": {
       "Default": "Information",

--- a/backend/src/PersonalFinanceTracker.Infrastructure/DependencyInjection.cs
+++ b/backend/src/PersonalFinanceTracker.Infrastructure/DependencyInjection.cs
@@ -1,0 +1,19 @@
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using PersonalFinanceTracker.Infrastructure.Persistence;
+
+namespace PersonalFinanceTracker.Infrastructure;
+
+public static class DependencyInjection
+{
+    public static IServiceCollection AddInfrastructure(this IServiceCollection services, IConfiguration configuration)
+    {
+        var connectionString = configuration.GetConnectionString("DefaultConnection")
+            ?? throw new InvalidOperationException("Connection string 'DefaultConnection' was not found.");
+
+        services.AddDbContext<AppDbContext>(options => options.UseSqlServer(connectionString));
+
+        return services;
+    }
+}

--- a/backend/src/PersonalFinanceTracker.Infrastructure/Persistence/AppDbContext.cs
+++ b/backend/src/PersonalFinanceTracker.Infrastructure/Persistence/AppDbContext.cs
@@ -1,0 +1,7 @@
+using Microsoft.EntityFrameworkCore;
+
+namespace PersonalFinanceTracker.Infrastructure.Persistence;
+
+public sealed class AppDbContext(DbContextOptions<AppDbContext> options) : DbContext(options)
+{
+}

--- a/backend/src/PersonalFinanceTracker.Infrastructure/Persistence/DesignTimeDbContextFactory.cs
+++ b/backend/src/PersonalFinanceTracker.Infrastructure/Persistence/DesignTimeDbContextFactory.cs
@@ -1,0 +1,17 @@
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Design;
+
+namespace PersonalFinanceTracker.Infrastructure.Persistence;
+
+public sealed class DesignTimeDbContextFactory : IDesignTimeDbContextFactory<AppDbContext>
+{
+    public AppDbContext CreateDbContext(string[] args)
+    {
+        const string connectionString = "Server=localhost;Database=PersonalFinanceTrackerDb;Trusted_Connection=True;TrustServerCertificate=True;MultipleActiveResultSets=true";
+
+        var optionsBuilder = new DbContextOptionsBuilder<AppDbContext>();
+        optionsBuilder.UseSqlServer(connectionString);
+
+        return new AppDbContext(optionsBuilder.Options);
+    }
+}

--- a/backend/src/PersonalFinanceTracker.Infrastructure/PersonalFinanceTracker.Infrastructure.csproj
+++ b/backend/src/PersonalFinanceTracker.Infrastructure/PersonalFinanceTracker.Infrastructure.csproj
@@ -11,4 +11,13 @@
     <Nullable>enable</Nullable>
   </PropertyGroup>
 
+  <ItemGroup>
+    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="10.0.3" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="10.0.3">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+    <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="10.0.3" />
+  </ItemGroup>
+
 </Project>


### PR DESCRIPTION
## Summary

Configures EF Core with SQL Server for the backend foundation and wires Infrastructure DI into the API startup.

## Type of change

- [x] Feature
- [ ] Bug fix
- [ ] Refactor
- [ ] Documentation
- [ ] Chore
- [ ] Test

## Why this change

Phase 2 requires a production-style persistence foundation before defining domain entities and migrations. This sets up DbContext registration and SQL Server connectivity cleanly.

## Scope

- In scope:
  - Add EF Core packages in Infrastructure (`Microsoft.EntityFrameworkCore`, `Design`, `SqlServer`)
  - Add `AppDbContext`
  - Add `DesignTimeDbContextFactory` for migration tooling
  - Add Infrastructure DI extension (`AddInfrastructure`)
  - Register Infrastructure in API `Program.cs`
  - Add `DefaultConnection` in `appsettings.Development.json`
- Out of scope:
  - Domain entities and configurations
  - Repositories/services
  - Migrations creation
  - API endpoint implementation

## Implementation notes

- DbContext is configured in Infrastructure and consumed via DI in API to maintain separation of concerns.
- Design-time factory enables EF tooling without requiring API host execution.
- Connection string is currently local SQL Server for development.

## Testing

- [x] Build passes locally
- [ ] Lint passes
- [ ] Tests added/updated where needed
- [x] Manual verification completed

### Test evidence

- `dotnet build backend/PersonalFinanceTracker.slnx` → Build succeeded (0 errors)

## Screenshots / API examples (if applicable)

N/A for infrastructure setup.

## Checklist

- [x] Single-responsibility PR (no unrelated changes)
- [x] Commit messages are clear and professional
- [x] Docs updated where needed
- [x] No secrets/tokens included
- [x] Ready for review