### PR TITLE
feat(domain): add core finance entities and transaction type enum

### DIFF
--- a/backend/src/PersonalFinanceTracker.Domain/Class1.cs
+++ b/backend/src/PersonalFinanceTracker.Domain/Class1.cs
@@ -1,6 +1,0 @@
-﻿namespace PersonalFinanceTracker.Domain;
-
-public class Class1
-{
-
-}

--- a/backend/src/PersonalFinanceTracker.Domain/Common/BaseEntity.cs
+++ b/backend/src/PersonalFinanceTracker.Domain/Common/BaseEntity.cs
@@ -1,0 +1,8 @@
+namespace PersonalFinanceTracker.Domain.Common;
+
+public abstract class BaseEntity
+{
+    public Guid Id { get; set; } = Guid.NewGuid();
+    public DateTime CreatedAtUtc { get; set; } = DateTime.UtcNow;
+    public DateTime UpdatedAtUtc { get; set; } = DateTime.UtcNow;
+}

--- a/backend/src/PersonalFinanceTracker.Domain/Entities/Budget.cs
+++ b/backend/src/PersonalFinanceTracker.Domain/Entities/Budget.cs
@@ -1,0 +1,15 @@
+using PersonalFinanceTracker.Domain.Common;
+
+namespace PersonalFinanceTracker.Domain.Entities;
+
+public sealed class Budget : BaseEntity
+{
+    public Guid UserId { get; set; }
+    public Guid CategoryId { get; set; }
+    public int Year { get; set; }
+    public int Month { get; set; }
+    public decimal LimitAmount { get; set; }
+
+    public User? User { get; set; }
+    public Category? Category { get; set; }
+}

--- a/backend/src/PersonalFinanceTracker.Domain/Entities/Category.cs
+++ b/backend/src/PersonalFinanceTracker.Domain/Entities/Category.cs
@@ -1,0 +1,15 @@
+using PersonalFinanceTracker.Domain.Common;
+
+namespace PersonalFinanceTracker.Domain.Entities;
+
+public sealed class Category : BaseEntity
+{
+    public Guid UserId { get; set; }
+    public string Name { get; set; } = string.Empty;
+    public string? Description { get; set; }
+    public bool IsDefault { get; set; }
+
+    public User? User { get; set; }
+    public ICollection<Transaction> Transactions { get; set; } = new List<Transaction>();
+    public ICollection<Budget> Budgets { get; set; } = new List<Budget>();
+}

--- a/backend/src/PersonalFinanceTracker.Domain/Entities/Transaction.cs
+++ b/backend/src/PersonalFinanceTracker.Domain/Entities/Transaction.cs
@@ -1,0 +1,17 @@
+using PersonalFinanceTracker.Domain.Common;
+using PersonalFinanceTracker.Domain.Enums;
+
+namespace PersonalFinanceTracker.Domain.Entities;
+
+public sealed class Transaction : BaseEntity
+{
+    public Guid UserId { get; set; }
+    public Guid CategoryId { get; set; }
+    public decimal Amount { get; set; }
+    public TransactionType Type { get; set; }
+    public DateTime TransactionDateUtc { get; set; }
+    public string? Note { get; set; }
+
+    public User? User { get; set; }
+    public Category? Category { get; set; }
+}

--- a/backend/src/PersonalFinanceTracker.Domain/Entities/User.cs
+++ b/backend/src/PersonalFinanceTracker.Domain/Entities/User.cs
@@ -1,0 +1,14 @@
+using PersonalFinanceTracker.Domain.Common;
+
+namespace PersonalFinanceTracker.Domain.Entities;
+
+public sealed class User : BaseEntity
+{
+    public string ExternalAuthId { get; set; } = string.Empty;
+    public string Email { get; set; } = string.Empty;
+    public string FullName { get; set; } = string.Empty;
+
+    public ICollection<Category> Categories { get; set; } = new List<Category>();
+    public ICollection<Transaction> Transactions { get; set; } = new List<Transaction>();
+    public ICollection<Budget> Budgets { get; set; } = new List<Budget>();
+}

--- a/backend/src/PersonalFinanceTracker.Domain/Enums/TransactionType.cs
+++ b/backend/src/PersonalFinanceTracker.Domain/Enums/TransactionType.cs
@@ -1,0 +1,7 @@
+namespace PersonalFinanceTracker.Domain.Enums;
+
+public enum TransactionType
+{
+    Income = 1,
+    Expense = 2
+}


### PR DESCRIPTION
## Summary

Adds core domain model foundation for Personal Finance Tracker backend, including base entity timestamps, transaction type enum, and primary finance entities.

## Type of change

- [x] Feature
- [ ] Bug fix
- [ ] Refactor
- [ ] Documentation
- [ ] Chore
- [ ] Test

## Why this change

Domain entities are required before EF model configurations and migrations. This establishes a clear and consistent domain vocabulary for upcoming API and persistence layers.

## Scope

- In scope:
  - Add `BaseEntity` with `Id`, `CreatedAtUtc`, `UpdatedAtUtc`
  - Add `TransactionType` enum (`Income`, `Expense`)
  - Add entities: `User`, `Category`, `Transaction`, `Budget`
  - Remove template `Class1.cs`
- Out of scope:
  - EF entity configurations
  - Migrations
  - Repositories/services/controllers

## Implementation notes

- Navigation properties were added to support relationship mapping in the next step.
- UTC field naming is explicit to avoid timezone ambiguity.
- This commit is intentionally domain-only and does not include infrastructure behavior.

## Testing

- [x] Build passes locally
- [ ] Lint passes
- [ ] Tests added/updated where needed
- [x] Manual verification completed

### Test evidence

- `dotnet build backend/PersonalFinanceTracker.slnx` → Build succeeded (0 errors)

## Screenshots / API examples (if applicable)

N/A for domain-layer changes.

## Checklist

- [x] Single-responsibility PR (no unrelated changes)
- [x] Commit messages are clear and professional
- [x] Docs updated where needed
- [x] No secrets/tokens included
- [x] Ready for review