### PR TITLE
feat(app): implement category service with EF Core and DI registration

### DIFF
--- a/backend/src/PersonalFinanceTracker.Infrastructure/DependencyInjection.cs
+++ b/backend/src/PersonalFinanceTracker.Infrastructure/DependencyInjection.cs
@@ -1,7 +1,9 @@
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
+using PersonalFinanceTracker.Application.Abstractions.Services;
 using PersonalFinanceTracker.Infrastructure.Persistence;
+using PersonalFinanceTracker.Infrastructure.Services;
 
 namespace PersonalFinanceTracker.Infrastructure;
 
@@ -13,6 +15,8 @@ public static class DependencyInjection
             ?? throw new InvalidOperationException("Connection string 'DefaultConnection' was not found.");
 
         services.AddDbContext<AppDbContext>(options => options.UseSqlServer(connectionString));
+
+        services.AddScoped<ICategoryService, CategoryService>();
 
         return services;
     }

--- a/backend/src/PersonalFinanceTracker.Infrastructure/Services/CategoryService.cs
+++ b/backend/src/PersonalFinanceTracker.Infrastructure/Services/CategoryService.cs
@@ -1,0 +1,38 @@
+using Microsoft.EntityFrameworkCore;
+using PersonalFinanceTracker.Application.Abstractions.Services;
+using PersonalFinanceTracker.Application.Contracts.Categories;
+using PersonalFinanceTracker.Domain.Entities;
+using PersonalFinanceTracker.Infrastructure.Persistence;
+
+namespace PersonalFinanceTracker.Infrastructure.Services;
+
+public sealed class CategoryService(AppDbContext dbContext) : ICategoryService
+{
+    public async Task<CategoryDto> CreateAsync(CreateCategoryRequest request, CancellationToken cancellationToken = default)
+    {
+        var category = new Category
+        {
+            UserId = request.UserId,
+            Name = request.Name.Trim(),
+            Description = request.Description?.Trim(),
+            IsDefault = request.IsDefault,
+            CreatedAtUtc = DateTime.UtcNow,
+            UpdatedAtUtc = DateTime.UtcNow
+        };
+
+        dbContext.Categories.Add(category);
+        await dbContext.SaveChangesAsync(cancellationToken);
+
+        return new CategoryDto(category.Id, category.UserId, category.Name, category.Description, category.IsDefault);
+    }
+
+    public async Task<IReadOnlyList<CategoryDto>> GetAllAsync(Guid userId, CancellationToken cancellationToken = default)
+    {
+        return await dbContext.Categories
+            .AsNoTracking()
+            .Where(x => x.UserId == userId)
+            .OrderBy(x => x.Name)
+            .Select(x => new CategoryDto(x.Id, x.UserId, x.Name, x.Description, x.IsDefault))
+            .ToListAsync(cancellationToken);
+    }
+}


### PR DESCRIPTION
## Summary

Implements `ICategoryService` with EF Core and wires it into dependency injection so category endpoints can execute real create/list behavior.

## Type of change

- [x] Feature
- [ ] Bug fix
- [ ] Refactor
- [ ] Documentation
- [ ] Chore
- [ ] Test

## Why this change

Phase 2 still needed concrete service implementations. This starts that layer in a controlled way by completing one service end-to-end.

## Scope

- In scope:
  - Add `CategoryService` implementation in Infrastructure
  - Implement category create and list methods using `AppDbContext`
  - Register `ICategoryService` in Infrastructure DI
- Out of scope:
  - Transaction/Budget/Summary service implementations
  - Endpoint integration tests
  - advanced error mapping for DB constraint violations

## Implementation notes

- `CreateAsync` trims inputs and persists category.
- `GetAllAsync` uses `AsNoTracking`, filters by `userId`, and orders by name.
- Returns Application DTOs directly to maintain current thin-controller flow.

## Testing

- [x] Build passes locally
- [ ] Lint passes
- [ ] Tests added/updated where needed
- [x] Manual verification completed

### Test evidence

- `dotnet build backend/PersonalFinanceTracker.slnx` → Build succeeded (0 errors)

## Screenshots / API examples (if applicable)

N/A for service-layer implementation.

## Checklist

- [x] Single-responsibility PR (no unrelated changes)
- [x] Commit messages are clear and professional
- [x] Docs updated where needed
- [x] No secrets/tokens included
- [x] Ready for review