### PR TITLE
feat(app): implement transaction service with EF Core and DI wiring

### DIFF
--- a/backend/src/PersonalFinanceTracker.Infrastructure/DependencyInjection.cs
+++ b/backend/src/PersonalFinanceTracker.Infrastructure/DependencyInjection.cs
@@ -17,6 +17,7 @@ public static class DependencyInjection
         services.AddDbContext<AppDbContext>(options => options.UseSqlServer(connectionString));
 
         services.AddScoped<ICategoryService, CategoryService>();
+        services.AddScoped<ITransactionService, TransactionService>();
 
         return services;
     }

--- a/backend/src/PersonalFinanceTracker.Infrastructure/Services/TransactionService.cs
+++ b/backend/src/PersonalFinanceTracker.Infrastructure/Services/TransactionService.cs
@@ -1,0 +1,118 @@
+using Microsoft.EntityFrameworkCore;
+using PersonalFinanceTracker.Application.Abstractions.Services;
+using PersonalFinanceTracker.Application.Contracts.Transactions;
+using PersonalFinanceTracker.Domain.Entities;
+using PersonalFinanceTracker.Infrastructure.Persistence;
+
+namespace PersonalFinanceTracker.Infrastructure.Services;
+
+public sealed class TransactionService(AppDbContext dbContext) : ITransactionService
+{
+    public async Task<TransactionDto> CreateAsync(CreateTransactionRequest request, CancellationToken cancellationToken = default)
+    {
+        await EnsureCategoryBelongsToUserAsync(request.CategoryId, request.UserId, cancellationToken);
+
+        var transaction = new Transaction
+        {
+            UserId = request.UserId,
+            CategoryId = request.CategoryId,
+            Amount = request.Amount,
+            Type = request.Type,
+            TransactionDateUtc = request.TransactionDateUtc,
+            Note = request.Note?.Trim(),
+            CreatedAtUtc = DateTime.UtcNow,
+            UpdatedAtUtc = DateTime.UtcNow
+        };
+
+        dbContext.Transactions.Add(transaction);
+        await dbContext.SaveChangesAsync(cancellationToken);
+
+        return ToDto(transaction);
+    }
+
+    public async Task<IReadOnlyList<TransactionDto>> GetAsync(TransactionQuery query, CancellationToken cancellationToken = default)
+    {
+        var dataQuery = dbContext.Transactions
+            .AsNoTracking()
+            .Where(x => x.UserId == query.UserId);
+
+        if (query.FromDateUtc.HasValue)
+        {
+            dataQuery = dataQuery.Where(x => x.TransactionDateUtc >= query.FromDateUtc.Value);
+        }
+
+        if (query.ToDateUtc.HasValue)
+        {
+            dataQuery = dataQuery.Where(x => x.TransactionDateUtc <= query.ToDateUtc.Value);
+        }
+
+        if (query.CategoryId.HasValue)
+        {
+            dataQuery = dataQuery.Where(x => x.CategoryId == query.CategoryId.Value);
+        }
+
+        if (query.Type.HasValue)
+        {
+            dataQuery = dataQuery.Where(x => x.Type == query.Type.Value);
+        }
+
+        return await dataQuery
+            .OrderByDescending(x => x.TransactionDateUtc)
+            .Select(x => ToDto(x))
+            .ToListAsync(cancellationToken);
+    }
+
+    public async Task<TransactionDto> UpdateAsync(Guid transactionId, UpdateTransactionRequest request, CancellationToken cancellationToken = default)
+    {
+        var transaction = await dbContext.Transactions
+            .FirstOrDefaultAsync(x => x.Id == transactionId, cancellationToken)
+            ?? throw new KeyNotFoundException($"Transaction '{transactionId}' was not found.");
+
+        await EnsureCategoryBelongsToUserAsync(request.CategoryId, transaction.UserId, cancellationToken);
+
+        transaction.CategoryId = request.CategoryId;
+        transaction.Amount = request.Amount;
+        transaction.Type = request.Type;
+        transaction.TransactionDateUtc = request.TransactionDateUtc;
+        transaction.Note = request.Note?.Trim();
+        transaction.UpdatedAtUtc = DateTime.UtcNow;
+
+        await dbContext.SaveChangesAsync(cancellationToken);
+
+        return ToDto(transaction);
+    }
+
+    public async Task DeleteAsync(Guid transactionId, CancellationToken cancellationToken = default)
+    {
+        var transaction = await dbContext.Transactions
+            .FirstOrDefaultAsync(x => x.Id == transactionId, cancellationToken)
+            ?? throw new KeyNotFoundException($"Transaction '{transactionId}' was not found.");
+
+        dbContext.Transactions.Remove(transaction);
+        await dbContext.SaveChangesAsync(cancellationToken);
+    }
+
+    private async Task EnsureCategoryBelongsToUserAsync(Guid categoryId, Guid userId, CancellationToken cancellationToken)
+    {
+        var categoryExists = await dbContext.Categories
+            .AsNoTracking()
+            .AnyAsync(x => x.Id == categoryId && x.UserId == userId, cancellationToken);
+
+        if (!categoryExists)
+        {
+            throw new InvalidOperationException("Category was not found for this user.");
+        }
+    }
+
+    private static TransactionDto ToDto(Transaction transaction)
+    {
+        return new TransactionDto(
+            transaction.Id,
+            transaction.UserId,
+            transaction.CategoryId,
+            transaction.Amount,
+            transaction.Type,
+            transaction.TransactionDateUtc,
+            transaction.Note);
+    }
+}


### PR DESCRIPTION
## Summary

Implements `ITransactionService` using EF Core and wires it through DI to enable real transaction create/read/update/delete flows.

## Type of change

- [x] Feature
- [ ] Bug fix
- [ ] Refactor
- [ ] Documentation
- [ ] Chore
- [ ] Test

## Why this change

Phase 2 still required concrete service implementations behind controller contracts. This completes transaction workflow behavior in one focused step.

## Scope

- In scope:
  - Add `TransactionService` implementation in Infrastructure
  - Implement methods: `CreateAsync`, `GetAsync`, `UpdateAsync`, `DeleteAsync`
  - Add category ownership guard (`categoryId` must belong to user)
  - Register `ITransactionService` in DI
- Out of scope:
  - Budget and summary service implementations
  - advanced exception-to-HTTP mapping
  - integration tests for transaction flows

## Implementation notes

- Queries are `AsNoTracking` for read path.
- Filters support date range, category, and transaction type.
- Update/Delete throw `KeyNotFoundException` when record is missing.
- Category-user consistency is checked before create/update to avoid cross-user linkage.

## Testing

- [x] Build passes locally
- [ ] Lint passes
- [ ] Tests added/updated where needed
- [x] Manual verification completed

### Test evidence

- `dotnet build backend/PersonalFinanceTracker.slnx` → Build succeeded (0 errors)

## Screenshots / API examples (if applicable)

N/A for service-layer implementation.

## Checklist

- [x] Single-responsibility PR (no unrelated changes)
- [x] Commit messages are clear and professional
- [x] Docs updated where needed
- [x] No secrets/tokens included
- [x] Ready for review