### PR TITLE
feat(app): implement budget service with monthly status aggregation

### DIFF
--- a/backend/src/PersonalFinanceTracker.Infrastructure/DependencyInjection.cs
+++ b/backend/src/PersonalFinanceTracker.Infrastructure/DependencyInjection.cs
@@ -18,6 +18,7 @@ public static class DependencyInjection
 
         services.AddScoped<ICategoryService, CategoryService>();
         services.AddScoped<ITransactionService, TransactionService>();
+        services.AddScoped<IBudgetService, BudgetService>();
 
         return services;
     }

--- a/backend/src/PersonalFinanceTracker.Infrastructure/Services/BudgetService.cs
+++ b/backend/src/PersonalFinanceTracker.Infrastructure/Services/BudgetService.cs
@@ -1,0 +1,119 @@
+using Microsoft.EntityFrameworkCore;
+using PersonalFinanceTracker.Application.Abstractions.Services;
+using PersonalFinanceTracker.Application.Contracts.Budgets;
+using PersonalFinanceTracker.Domain.Entities;
+using PersonalFinanceTracker.Domain.Enums;
+using PersonalFinanceTracker.Infrastructure.Persistence;
+
+namespace PersonalFinanceTracker.Infrastructure.Services;
+
+public sealed class BudgetService(AppDbContext dbContext) : IBudgetService
+{
+    public async Task<BudgetDto> CreateAsync(CreateBudgetRequest request, CancellationToken cancellationToken = default)
+    {
+        await EnsureCategoryBelongsToUserAsync(request.CategoryId, request.UserId, cancellationToken);
+
+        var existingBudget = await dbContext.Budgets
+            .AsNoTracking()
+            .AnyAsync(
+                x => x.UserId == request.UserId
+                     && x.CategoryId == request.CategoryId
+                     && x.Year == request.Year
+                     && x.Month == request.Month,
+                cancellationToken);
+
+        if (existingBudget)
+        {
+            throw new InvalidOperationException("Budget already exists for this category and month.");
+        }
+
+        var budget = new Budget
+        {
+            UserId = request.UserId,
+            CategoryId = request.CategoryId,
+            Year = request.Year,
+            Month = request.Month,
+            LimitAmount = request.LimitAmount,
+            CreatedAtUtc = DateTime.UtcNow,
+            UpdatedAtUtc = DateTime.UtcNow
+        };
+
+        dbContext.Budgets.Add(budget);
+        await dbContext.SaveChangesAsync(cancellationToken);
+
+        return new BudgetDto(
+            budget.Id,
+            budget.UserId,
+            budget.CategoryId,
+            budget.Year,
+            budget.Month,
+            budget.LimitAmount);
+    }
+
+    public async Task<IReadOnlyList<BudgetStatusDto>> GetMonthlyStatusAsync(Guid userId, int year, int month, CancellationToken cancellationToken = default)
+    {
+        var budgets = await dbContext.Budgets
+            .AsNoTracking()
+            .Where(x => x.UserId == userId && x.Year == year && x.Month == month)
+            .Join(
+                dbContext.Categories.AsNoTracking(),
+                budget => budget.CategoryId,
+                category => category.Id,
+                (budget, category) => new
+                {
+                    budget.Id,
+                    budget.CategoryId,
+                    CategoryName = category.Name,
+                    budget.LimitAmount
+                })
+            .ToListAsync(cancellationToken);
+
+        if (budgets.Count == 0)
+        {
+            return [];
+        }
+
+        var periodStart = new DateTime(year, month, 1, 0, 0, 0, DateTimeKind.Utc);
+        var periodEnd = periodStart.AddMonths(1);
+
+        var spentByCategory = await dbContext.Transactions
+            .AsNoTracking()
+            .Where(x => x.UserId == userId
+                        && x.Type == TransactionType.Expense
+                        && x.TransactionDateUtc >= periodStart
+                        && x.TransactionDateUtc < periodEnd)
+            .GroupBy(x => x.CategoryId)
+            .Select(g => new
+            {
+                CategoryId = g.Key,
+                SpentAmount = g.Sum(x => x.Amount)
+            })
+            .ToDictionaryAsync(x => x.CategoryId, x => x.SpentAmount, cancellationToken);
+
+        return budgets
+            .Select(x =>
+            {
+                var spentAmount = spentByCategory.GetValueOrDefault(x.CategoryId, 0m);
+                return new BudgetStatusDto(
+                    x.Id,
+                    x.CategoryId,
+                    x.CategoryName,
+                    x.LimitAmount,
+                    spentAmount,
+                    x.LimitAmount - spentAmount);
+            })
+            .ToList();
+    }
+
+    private async Task EnsureCategoryBelongsToUserAsync(Guid categoryId, Guid userId, CancellationToken cancellationToken)
+    {
+        var categoryExists = await dbContext.Categories
+            .AsNoTracking()
+            .AnyAsync(x => x.Id == categoryId && x.UserId == userId, cancellationToken);
+
+        if (!categoryExists)
+        {
+            throw new InvalidOperationException("Category was not found for this user.");
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Implements `IBudgetService` with EF Core and registers it in DI to support budget creation and monthly budget-status retrieval.

## Type of change

- [x] Feature
- [ ] Bug fix
- [ ] Refactor
- [ ] Documentation
- [ ] Chore
- [ ] Test

## Why this change

Phase 2 requires real budget workflow behavior behind controller contracts. This step adds service logic while keeping scope isolated to budget functionality.

## Scope

- In scope:
  - Add `BudgetService` implementation
  - Implement `CreateAsync` with duplicate-budget guard
  - Implement `GetMonthlyStatusAsync` with expense aggregation per category
  - Register `IBudgetService` in `DependencyInjection`
- Out of scope:
  - Summary service implementation
  - custom domain exceptions/mapping
  - endpoint integration tests

## Implementation notes

- Enforces category-user ownership check before creating budget.
- Prevents duplicate monthly budget per `(UserId, CategoryId, Year, Month)`.
- Computes `SpentAmount` from expense transactions only (`TransactionType.Expense`).
- Returns `RemainingAmount = LimitAmount - SpentAmount`.

## Testing

- [x] Build passes locally
- [ ] Lint passes
- [ ] Tests added/updated where needed
- [x] Manual verification completed

### Test evidence

- `dotnet build backend/PersonalFinanceTracker.slnx` → Build succeeded (0 errors)

## Screenshots / API examples (if applicable)

N/A for service-layer implementation.

## Checklist

- [x] Single-responsibility PR (no unrelated changes)
- [x] Commit messages are clear and professional
- [x] Docs updated where needed
- [x] No secrets/tokens included
- [x] Ready for review