### PR TITLE
feat(app): implement monthly summary service with category breakdown

### DIFF
--- a/backend/src/PersonalFinanceTracker.Infrastructure/DependencyInjection.cs
+++ b/backend/src/PersonalFinanceTracker.Infrastructure/DependencyInjection.cs
@@ -19,6 +19,7 @@ public static class DependencyInjection
         services.AddScoped<ICategoryService, CategoryService>();
         services.AddScoped<ITransactionService, TransactionService>();
         services.AddScoped<IBudgetService, BudgetService>();
+        services.AddScoped<ISummaryService, SummaryService>();
 
         return services;
     }

--- a/backend/src/PersonalFinanceTracker.Infrastructure/Services/SummaryService.cs
+++ b/backend/src/PersonalFinanceTracker.Infrastructure/Services/SummaryService.cs
@@ -1,0 +1,59 @@
+using Microsoft.EntityFrameworkCore;
+using PersonalFinanceTracker.Application.Abstractions.Services;
+using PersonalFinanceTracker.Application.Contracts.Summaries;
+using PersonalFinanceTracker.Domain.Enums;
+using PersonalFinanceTracker.Infrastructure.Persistence;
+
+namespace PersonalFinanceTracker.Infrastructure.Services;
+
+public sealed class SummaryService(AppDbContext dbContext) : ISummaryService
+{
+    public async Task<MonthlySummaryDto> GetMonthlySummaryAsync(Guid userId, int year, int month, CancellationToken cancellationToken = default)
+    {
+        var periodStart = new DateTime(year, month, 1, 0, 0, 0, DateTimeKind.Utc);
+        var periodEnd = periodStart.AddMonths(1);
+
+        var transactions = dbContext.Transactions
+            .AsNoTracking()
+            .Where(x => x.UserId == userId
+                        && x.TransactionDateUtc >= periodStart
+                        && x.TransactionDateUtc < periodEnd);
+
+        var totalIncome = await transactions
+            .Where(x => x.Type == TransactionType.Income)
+            .SumAsync(x => (decimal?)x.Amount, cancellationToken) ?? 0m;
+
+        var totalExpense = await transactions
+            .Where(x => x.Type == TransactionType.Expense)
+            .SumAsync(x => (decimal?)x.Amount, cancellationToken) ?? 0m;
+
+        var categoryBreakdown = await transactions
+            .Where(x => x.Type == TransactionType.Expense)
+            .Join(
+                dbContext.Categories.AsNoTracking(),
+                transaction => transaction.CategoryId,
+                category => category.Id,
+                (transaction, category) => new
+                {
+                    category.Id,
+                    category.Name,
+                    transaction.Amount
+                })
+            .GroupBy(x => new { x.Id, x.Name })
+            .Select(group => new CategorySpendDto(
+                group.Key.Id,
+                group.Key.Name,
+                group.Sum(x => x.Amount)))
+            .OrderByDescending(x => x.Amount)
+            .ToListAsync(cancellationToken);
+
+        return new MonthlySummaryDto(
+            userId,
+            year,
+            month,
+            totalIncome,
+            totalExpense,
+            totalIncome - totalExpense,
+            categoryBreakdown);
+    }
+}


### PR DESCRIPTION
## Summary

Implements `ISummaryService` with EF Core to return monthly financial summary (income, expense, net savings, and expense category breakdown), and registers it in DI.

## Type of change

- [x] Feature
- [ ] Bug fix
- [ ] Refactor
- [ ] Documentation
- [ ] Chore
- [ ] Test

## Why this change

Phase 2 needed real behavior behind the `SummaryController` contract. This completes the summary service so monthly dashboard/report endpoints can return meaningful data.

## Scope

- In scope:
  - Add `SummaryService` implementation
  - Implement monthly summary computation for:
    - total income
    - total expense
    - net savings
    - category-level expense breakdown
  - Register `ISummaryService` in `DependencyInjection`
- Out of scope:
  - integration tests
  - caching/performance tuning
  - custom exception mapping

## Implementation notes

- Uses UTC month window `[periodStart, periodEnd)`.
- Calculates income/expense via filtered aggregates.
- Category breakdown includes only expense transactions, grouped and sorted by amount desc.

## Testing

- [x] Build passes locally
- [ ] Lint passes
- [ ] Tests added/updated where needed
- [x] Manual verification completed

### Test evidence

- `dotnet build backend/PersonalFinanceTracker.slnx` → Build succeeded (0 errors)

## Screenshots / API examples (if applicable)

N/A for service-layer implementation.

## Checklist

- [x] Single-responsibility PR (no unrelated changes)
- [x] Commit messages are clear and professional
- [x] Docs updated where needed
- [x] No secrets/tokens included
- [x] Ready for review