### PR TITLE
feat(api): map business exceptions to 400/404/409 responses

### DIFF
--- a/backend/src/PersonalFinanceTracker.Api/Middleware/GlobalExceptionMiddleware.cs
+++ b/backend/src/PersonalFinanceTracker.Api/Middleware/GlobalExceptionMiddleware.cs
@@ -13,20 +13,41 @@ public sealed class GlobalExceptionMiddleware(RequestDelegate next, ILogger<Glob
         }
         catch (Exception exception)
         {
-            logger.LogError(exception, "Unhandled exception. TraceId: {TraceId}", context.TraceIdentifier);
+            var (statusCode, title) = MapException(exception);
 
-            context.Response.StatusCode = (int)HttpStatusCode.InternalServerError;
+            if (statusCode >= StatusCodes.Status500InternalServerError)
+            {
+                logger.LogError(exception, "Unhandled exception. TraceId: {TraceId}", context.TraceIdentifier);
+            }
+            else
+            {
+                logger.LogWarning(exception, "Handled exception. TraceId: {TraceId}", context.TraceIdentifier);
+            }
+
+            context.Response.StatusCode = statusCode;
             context.Response.ContentType = "application/json";
 
             var errorResponse = new
             {
-                title = "Unexpected server error",
-                status = context.Response.StatusCode,
+                title,
+                status = statusCode,
+                detail = exception.Message,
                 traceId = context.TraceIdentifier
             };
 
             var payload = JsonSerializer.Serialize(errorResponse);
             await context.Response.WriteAsync(payload);
         }
+    }
+
+    private static (int StatusCode, string Title) MapException(Exception exception)
+    {
+        return exception switch
+        {
+            KeyNotFoundException => (StatusCodes.Status404NotFound, "Resource not found"),
+            InvalidOperationException => (StatusCodes.Status409Conflict, "Business rule conflict"),
+            ArgumentException => (StatusCodes.Status400BadRequest, "Invalid request"),
+            _ => (StatusCodes.Status500InternalServerError, "Unexpected server error")
+        };
     }
 }


### PR DESCRIPTION
## Summary

Implements Phase 3 PR A: maps common domain/application exceptions to stable HTTP status codes and standardized error payloads.

## Type of change

- [x] Feature
- [ ] Bug fix
- [ ] Refactor
- [ ] Documentation
- [ ] Chore
- [ ] Test

## Why this change

Current API behavior can surface business failures as generic 500 responses. This PR improves API contract correctness without changing business logic paths.

## Scope

- In scope:
  - Update global exception middleware mapping:
    - `ArgumentException` -> `400 Bad Request`
    - `KeyNotFoundException` -> `404 Not Found`
    - `InvalidOperationException` -> `409 Conflict`
    - fallback -> `500 Internal Server Error`
  - Keep standardized JSON payload (`title`, `status`, `detail`, `traceId`)
  - Use warning logs for handled business exceptions and error logs for unexpected failures
- Out of scope:
  - service/business logic changes
  - validation rule changes
  - integration tests

## Implementation notes

- This is backward-safe for existing successful flows (no behavior change on success path).
- Only error-path semantics are improved to align with production API expectations.

## Testing

- [x] Build passes locally
- [ ] Lint passes
- [ ] Tests added/updated where needed
- [x] Manual verification completed

### Test evidence

- `dotnet build backend/PersonalFinanceTracker.slnx` → Build succeeded (0 errors)

## Screenshots / API examples (if applicable)

N/A for middleware-only behavior change.

## Checklist

- [x] Single-responsibility PR (no unrelated changes)
- [x] Commit messages are clear and professional
- [x] Docs updated where needed
- [x] No secrets/tokens included
- [x] Ready for review