### PR TITLE
feat(app): harden service guards for conflicts and invalid query ranges

### DIFF
--- a/backend/src/PersonalFinanceTracker.Infrastructure/Services/BudgetService.cs
+++ b/backend/src/PersonalFinanceTracker.Infrastructure/Services/BudgetService.cs
@@ -11,6 +11,7 @@ public sealed class BudgetService(AppDbContext dbContext) : IBudgetService
 {
     public async Task<BudgetDto> CreateAsync(CreateBudgetRequest request, CancellationToken cancellationToken = default)
     {
+        EnsurePeriodIsValid(request.Year, request.Month);
         await EnsureCategoryBelongsToUserAsync(request.CategoryId, request.UserId, cancellationToken);
 
         var existingBudget = await dbContext.Budgets
@@ -52,6 +53,8 @@ public sealed class BudgetService(AppDbContext dbContext) : IBudgetService
 
     public async Task<IReadOnlyList<BudgetStatusDto>> GetMonthlyStatusAsync(Guid userId, int year, int month, CancellationToken cancellationToken = default)
     {
+        EnsurePeriodIsValid(year, month);
+
         var budgets = await dbContext.Budgets
             .AsNoTracking()
             .Where(x => x.UserId == userId && x.Year == year && x.Month == month)
@@ -114,6 +117,19 @@ public sealed class BudgetService(AppDbContext dbContext) : IBudgetService
         if (!categoryExists)
         {
             throw new InvalidOperationException("Category was not found for this user.");
+        }
+    }
+
+    private static void EnsurePeriodIsValid(int year, int month)
+    {
+        if (year is < 2000 or > 2100)
+        {
+            throw new ArgumentException("year must be between 2000 and 2100.");
+        }
+
+        if (month is < 1 or > 12)
+        {
+            throw new ArgumentException("month must be between 1 and 12.");
         }
     }
 }

--- a/backend/src/PersonalFinanceTracker.Infrastructure/Services/CategoryService.cs
+++ b/backend/src/PersonalFinanceTracker.Infrastructure/Services/CategoryService.cs
@@ -10,10 +10,23 @@ public sealed class CategoryService(AppDbContext dbContext) : ICategoryService
 {
     public async Task<CategoryDto> CreateAsync(CreateCategoryRequest request, CancellationToken cancellationToken = default)
     {
+        var normalizedName = request.Name.Trim();
+
+        var nameExists = await dbContext.Categories
+            .AsNoTracking()
+            .AnyAsync(
+                x => x.UserId == request.UserId && x.Name.ToLower() == normalizedName.ToLower(),
+                cancellationToken);
+
+        if (nameExists)
+        {
+            throw new InvalidOperationException("Category with the same name already exists for this user.");
+        }
+
         var category = new Category
         {
             UserId = request.UserId,
-            Name = request.Name.Trim(),
+            Name = normalizedName,
             Description = request.Description?.Trim(),
             IsDefault = request.IsDefault,
             CreatedAtUtc = DateTime.UtcNow,

--- a/backend/src/PersonalFinanceTracker.Infrastructure/Services/TransactionService.cs
+++ b/backend/src/PersonalFinanceTracker.Infrastructure/Services/TransactionService.cs
@@ -32,6 +32,11 @@ public sealed class TransactionService(AppDbContext dbContext) : ITransactionSer
 
     public async Task<IReadOnlyList<TransactionDto>> GetAsync(TransactionQuery query, CancellationToken cancellationToken = default)
     {
+        if (query.FromDateUtc.HasValue && query.ToDateUtc.HasValue && query.FromDateUtc > query.ToDateUtc)
+        {
+            throw new ArgumentException("fromDateUtc cannot be greater than toDateUtc.");
+        }
+
         var dataQuery = dbContext.Transactions
             .AsNoTracking()
             .Where(x => x.UserId == query.UserId);


### PR DESCRIPTION
## Summary

Implements Phase 3 PR B service hardening by adding guard checks for common edge cases without changing happy-path behavior.

## Type of change

- [x] Feature
- [ ] Bug fix
- [ ] Refactor
- [ ] Documentation
- [ ] Chore
- [ ] Test

## Why this change

Even with core behavior implemented, services should fail early and predictably on invalid or conflicting inputs to avoid ambiguous DB/runtime errors.

## Scope

- In scope:
  - `CategoryService`: prevent duplicate category name per user (case-insensitive)
  - `TransactionService`: validate date-range filter (`fromDateUtc <= toDateUtc`)
  - `BudgetService`: validate period bounds (`year`, `month`) for create and status queries
- Out of scope:
  - API contract shape changes
  - integration tests
  - repository pattern refactor

## Implementation notes

- Duplicate category names now raise `InvalidOperationException` (mapped to 409 by PR A middleware).
- Invalid date-range and invalid period values raise `ArgumentException` (mapped to 400).
- Existing successful flows are untouched.

## Testing

- [x] Build passes locally
- [ ] Lint passes
- [ ] Tests added/updated where needed
- [x] Manual verification completed

### Test evidence

- `dotnet build backend/PersonalFinanceTracker.slnx` → Build succeeded (0 errors)

## Screenshots / API examples (if applicable)

N/A for service-only hardening.

## Checklist

- [x] Single-responsibility PR (no unrelated changes)
- [x] Commit messages are clear and professional
- [x] Docs updated where needed
- [x] No secrets/tokens included
- [x] Ready for review