### PR TITLE
test(integration): add budget and summary API flow coverage

### DIFF
--- a/backend/src/PersonalFinanceTracker.Infrastructure/Services/SummaryService.cs
+++ b/backend/src/PersonalFinanceTracker.Infrastructure/Services/SummaryService.cs
@@ -27,7 +27,7 @@ public sealed class SummaryService(AppDbContext dbContext) : ISummaryService
             .Where(x => x.Type == TransactionType.Expense)
             .SumAsync(x => (decimal?)x.Amount, cancellationToken) ?? 0m;
 
-        var categoryBreakdown = await transactions
+        var categoryBreakdownRaw = await transactions
             .Where(x => x.Type == TransactionType.Expense)
             .Join(
                 dbContext.Categories.AsNoTracking(),
@@ -40,12 +40,18 @@ public sealed class SummaryService(AppDbContext dbContext) : ISummaryService
                     transaction.Amount
                 })
             .GroupBy(x => new { x.Id, x.Name })
-            .Select(group => new CategorySpendDto(
+            .Select(group => new
+            {
                 group.Key.Id,
                 group.Key.Name,
-                group.Sum(x => x.Amount)))
+                Amount = group.Sum(x => x.Amount)
+            })
             .OrderByDescending(x => x.Amount)
             .ToListAsync(cancellationToken);
+
+        var categoryBreakdown = categoryBreakdownRaw
+            .Select(x => new CategorySpendDto(x.Id, x.Name, x.Amount))
+            .ToList();
 
         return new MonthlySummaryDto(
             userId,

--- a/backend/tests/PersonalFinanceTracker.IntegrationTests/BudgetsApiTests.cs
+++ b/backend/tests/PersonalFinanceTracker.IntegrationTests/BudgetsApiTests.cs
@@ -1,0 +1,90 @@
+using System.Net;
+using System.Net.Http.Json;
+using System.Text.Json;
+using PersonalFinanceTracker.Application.Contracts.Budgets;
+using PersonalFinanceTracker.Application.Contracts.Categories;
+using PersonalFinanceTracker.Application.Contracts.Transactions;
+using PersonalFinanceTracker.Domain.Enums;
+using PersonalFinanceTracker.IntegrationTests.TestHost;
+
+namespace PersonalFinanceTracker.IntegrationTests;
+
+public sealed class BudgetsApiTests : IClassFixture<PersonalFinanceApiFactory>
+{
+    private readonly HttpClient _client;
+    private readonly PersonalFinanceApiFactory _factory;
+
+    public BudgetsApiTests(PersonalFinanceApiFactory factory)
+    {
+        _factory = factory;
+        _client = factory.CreateClient(new Microsoft.AspNetCore.Mvc.Testing.WebApplicationFactoryClientOptions
+        {
+            BaseAddress = new Uri("https://localhost"),
+            AllowAutoRedirect = false
+        });
+    }
+
+    [Fact]
+    public async Task CreateBudget_ThenGetStatus_ShouldReturnSpentAndRemainingAmounts()
+    {
+        var userId = Guid.NewGuid();
+        await TestDataSeeder.SeedUserAsync(_factory, userId);
+
+        var categoryResponse = await _client.PostAsJsonAsync("/api/categories", new CreateCategoryRequest(userId, "Food", "Groceries", false));
+        var category = await categoryResponse.Content.ReadFromJsonAsync<CategoryDto>();
+
+        Assert.Equal(HttpStatusCode.Created, categoryResponse.StatusCode);
+        Assert.NotNull(category);
+
+        var now = DateTime.UtcNow;
+        var budgetRequest = new CreateBudgetRequest(userId, category!.Id, now.Year, now.Month, 2000m);
+        var budgetResponse = await _client.PostAsJsonAsync("/api/budgets", budgetRequest);
+
+        Assert.Equal(HttpStatusCode.Created, budgetResponse.StatusCode);
+
+        var expenseRequest = new CreateTransactionRequest(
+            userId,
+            category.Id,
+            650m,
+            TransactionType.Expense,
+            new DateTime(now.Year, now.Month, 10, 10, 0, 0, DateTimeKind.Utc),
+            "Weekly groceries");
+
+        var transactionResponse = await _client.PostAsJsonAsync("/api/transactions", expenseRequest);
+        Assert.Equal(HttpStatusCode.Created, transactionResponse.StatusCode);
+
+        var statusResponse = await _client.GetAsync($"/api/budgets/status?userId={userId}&year={now.Year}&month={now.Month}");
+        Assert.Equal(HttpStatusCode.OK, statusResponse.StatusCode);
+
+        var statuses = await statusResponse.Content.ReadFromJsonAsync<List<BudgetStatusDto>>();
+        Assert.NotNull(statuses);
+        Assert.Single(statuses!);
+        Assert.Equal(650m, statuses[0].SpentAmount);
+        Assert.Equal(1350m, statuses[0].RemainingAmount);
+    }
+
+    [Fact]
+    public async Task CreateBudget_DuplicateForSameMonth_ShouldReturnConflict()
+    {
+        var userId = Guid.NewGuid();
+        await TestDataSeeder.SeedUserAsync(_factory, userId);
+
+        var categoryResponse = await _client.PostAsJsonAsync("/api/categories", new CreateCategoryRequest(userId, "Rent", null, false));
+        var category = await categoryResponse.Content.ReadFromJsonAsync<CategoryDto>();
+
+        Assert.Equal(HttpStatusCode.Created, categoryResponse.StatusCode);
+        Assert.NotNull(category);
+
+        var now = DateTime.UtcNow;
+        var request = new CreateBudgetRequest(userId, category!.Id, now.Year, now.Month, 15000m);
+
+        var firstResponse = await _client.PostAsJsonAsync("/api/budgets", request);
+        Assert.Equal(HttpStatusCode.Created, firstResponse.StatusCode);
+
+        var secondResponse = await _client.PostAsJsonAsync("/api/budgets", request);
+        Assert.Equal(HttpStatusCode.Conflict, secondResponse.StatusCode);
+
+        var payload = await secondResponse.Content.ReadFromJsonAsync<JsonElement>();
+        Assert.Equal(409, payload.GetProperty("status").GetInt32());
+    }
+}

--- a/backend/tests/PersonalFinanceTracker.IntegrationTests/SummaryApiTests.cs
+++ b/backend/tests/PersonalFinanceTracker.IntegrationTests/SummaryApiTests.cs
@@ -1,0 +1,80 @@
+using System.Net;
+using System.Net.Http.Json;
+using PersonalFinanceTracker.Application.Contracts.Categories;
+using PersonalFinanceTracker.Application.Contracts.Summaries;
+using PersonalFinanceTracker.Application.Contracts.Transactions;
+using PersonalFinanceTracker.Domain.Enums;
+using PersonalFinanceTracker.IntegrationTests.TestHost;
+
+namespace PersonalFinanceTracker.IntegrationTests;
+
+public sealed class SummaryApiTests : IClassFixture<PersonalFinanceApiFactory>
+{
+    private readonly HttpClient _client;
+    private readonly PersonalFinanceApiFactory _factory;
+
+    public SummaryApiTests(PersonalFinanceApiFactory factory)
+    {
+        _factory = factory;
+        _client = factory.CreateClient(new Microsoft.AspNetCore.Mvc.Testing.WebApplicationFactoryClientOptions
+        {
+            BaseAddress = new Uri("https://localhost"),
+            AllowAutoRedirect = false
+        });
+    }
+
+    [Fact]
+    public async Task GetMonthlySummary_ShouldReturnIncomeExpenseNetAndBreakdown()
+    {
+        var userId = Guid.NewGuid();
+        await TestDataSeeder.SeedUserAsync(_factory, userId);
+
+        var foodCategoryResponse = await _client.PostAsJsonAsync("/api/categories", new CreateCategoryRequest(userId, "Food", null, false));
+        var foodCategory = await foodCategoryResponse.Content.ReadFromJsonAsync<CategoryDto>();
+
+        var salaryCategoryResponse = await _client.PostAsJsonAsync("/api/categories", new CreateCategoryRequest(userId, "Salary", null, false));
+        var salaryCategory = await salaryCategoryResponse.Content.ReadFromJsonAsync<CategoryDto>();
+
+        Assert.Equal(HttpStatusCode.Created, foodCategoryResponse.StatusCode);
+        Assert.Equal(HttpStatusCode.Created, salaryCategoryResponse.StatusCode);
+        Assert.NotNull(foodCategory);
+        Assert.NotNull(salaryCategory);
+
+        var now = DateTime.UtcNow;
+
+        var incomeResponse = await _client.PostAsJsonAsync("/api/transactions", new CreateTransactionRequest(
+            userId,
+            salaryCategory!.Id,
+            5000m,
+            TransactionType.Income,
+            new DateTime(now.Year, now.Month, 2, 9, 0, 0, DateTimeKind.Utc),
+            "Monthly salary"));
+
+        var expenseResponse = await _client.PostAsJsonAsync("/api/transactions", new CreateTransactionRequest(
+            userId,
+            foodCategory!.Id,
+            1200m,
+            TransactionType.Expense,
+            new DateTime(now.Year, now.Month, 5, 20, 0, 0, DateTimeKind.Utc),
+            "Groceries"));
+
+        Assert.Equal(HttpStatusCode.Created, incomeResponse.StatusCode);
+        Assert.Equal(HttpStatusCode.Created, expenseResponse.StatusCode);
+
+        var summaryResponse = await _client.GetAsync($"/api/summary/monthly?userId={userId}&year={now.Year}&month={now.Month}");
+        var summaryBody = await summaryResponse.Content.ReadAsStringAsync();
+        Assert.True(summaryResponse.StatusCode == HttpStatusCode.OK, $"Expected 200 but got {(int)summaryResponse.StatusCode}: {summaryBody}");
+
+        var summary = System.Text.Json.JsonSerializer.Deserialize<MonthlySummaryDto>(summaryBody, new System.Text.Json.JsonSerializerOptions
+        {
+            PropertyNameCaseInsensitive = true
+        });
+        Assert.NotNull(summary);
+        Assert.Equal(5000m, summary!.TotalIncome);
+        Assert.Equal(1200m, summary.TotalExpense);
+        Assert.Equal(3800m, summary.NetSavings);
+        Assert.Single(summary.CategoryBreakdown);
+        Assert.Equal("Food", summary.CategoryBreakdown[0].CategoryName);
+        Assert.Equal(1200m, summary.CategoryBreakdown[0].Amount);
+    }
+}


### PR DESCRIPTION
## Summary

Implements Phase 3 PR D by adding integration tests for Budget and Summary API flows, and fixes a summary query translation issue exposed by test coverage.

## Type of change

- [ ] Feature
- [ ] Bug fix
- [ ] Refactor
- [ ] Documentation
- [ ] Chore
- [x] Test

## Why this change

Phase 3 requires end-to-end confidence for budget and summary behavior, not just category/transaction paths. Tests also surfaced a LINQ translation edge case in summary aggregation that needed a safe fix.

## Scope

- In scope:
  - Add budget API integration tests:
    - create budget + monthly status aggregation
    - duplicate monthly budget conflict
  - Add summary API integration test:
    - monthly totals and category breakdown
  - Fix summary service projection for EF translation compatibility
- Out of scope:
  - CI workflow changes
  - performance tuning/caching

## Implementation notes

- Summary aggregation now projects to anonymous type in SQL and maps to DTO after materialization.
- Existing successful behavior preserved; fix is translation-safe and covered by tests.

## Testing

- [x] Build passes locally
- [ ] Lint passes
- [x] Tests added/updated where needed
- [x] Manual verification completed

### Test evidence

- `dotnet test backend/tests/PersonalFinanceTracker.IntegrationTests/PersonalFinanceTracker.IntegrationTests.csproj` → Passed (7/7)
- `dotnet build backend/PersonalFinanceTracker.slnx` → Build succeeded (0 errors)

## Screenshots / API examples (if applicable)

N/A for test coverage and query translation fix.

## Checklist

- [x] Single-responsibility PR (no unrelated changes)
- [x] Commit messages are clear and professional
- [x] Docs updated where needed
- [x] No secrets/tokens included
- [x] Ready for review