### PR TITLE
Fix local runtime blockers: dashboard pageSize contract mismatch + dev HTTPS redirect trap

### DIFF
--- a/backend/src/PersonalFinanceTracker.Api/Program.cs
+++ b/backend/src/PersonalFinanceTracker.Api/Program.cs
@@ -253,7 +253,11 @@ if (app.Environment.IsDevelopment())
 }
 
 app.UseGlobalExceptionHandling();
-app.UseHttpsRedirection();
+
+if (!app.Environment.IsDevelopment())
+{
+    app.UseHttpsRedirection();
+}
 
 app.UseCors("FrontendCors");
 app.UseRateLimiter();

--- a/src/pages/DashboardPage.tsx
+++ b/src/pages/DashboardPage.tsx
@@ -29,7 +29,7 @@ export default function DashboardPage() {
         const [summaryData, budgetData, transactionData] = await Promise.all([
           getMonthlySummary(now.getUTCFullYear(), now.getUTCMonth() + 1),
           getBudgetStatus(now.getUTCFullYear(), now.getUTCMonth() + 1),
-          getTransactions({ page: 1, pageSize: 120, sortDirection: 'desc' }),
+          getTransactions({ page: 1, pageSize: 100, sortDirection: 'desc' }),
         ])
 
         setSummary(summaryData)


### PR DESCRIPTION
## Summary
Fixes two runtime blockers seen in local dev logs:
1) transaction page size validation exception (`pageSize must be between 1 and 100`)
2) API failures from HTTP->HTTPS redirect trap when HTTPS endpoint is unavailable/rejected in local setup

## Root cause
- Dashboard requested `pageSize=120`, violating backend validation contract.
- Backend always enforced HTTPS redirection, but local frontend/proxy/backend combinations could hit redirect loops or unreachable HTTPS endpoint (`ECONNREFUSED ::1:7121`).

## Changes
- Dashboard API call page size changed `120 -> 100` (max allowed by backend).
- In API startup pipeline, `UseHttpsRedirection()` is skipped in Development to keep local API calls stable.

## Validation
- `dotnet build backend/PersonalFinanceTracker.slnx` ✅
- `npm run build` ✅